### PR TITLE
Improved parameter exposure and much-improved README

### DIFF
--- a/R/parse_raw_data.R
+++ b/R/parse_raw_data.R
@@ -20,7 +20,10 @@ parse_raw_data <- function(input.filename,
 						   postprocessing.overrides = NA,
 						   known.matches = NA,
 						   remove.duplicates = TRUE,
-						   disable.nlp.correction = FALSE) {
+						   disable.nlp.correction = FALSE,
+						   cutree.h.combined = 5,
+						   cutree.h.title = 3,
+						   cutree.h.author = 3) {
 	## input parameter consistency checks
 	stopifnot(is.vector(input.filename, mode = "character"))
 	stopifnot(is.vector(output.prefix, mode = "character"))
@@ -32,6 +35,12 @@ parse_raw_data <- function(input.filename,
 			  is.na(known.matches))
 	stopifnot(is.logical(remove.duplicates))
 	stopifnot(is.logical(disable.nlp.correction))
+	stopifnot(is.numeric(cutree.h.combined))
+	stopifnot(is.numeric(cutree.h.title))
+	stopifnot(is.numeric(cutree.h.author))
+	stopifnot(cutree.h.combined > 0)
+	stopifnot(cutree.h.title > 0)
+	stopifnot(cutree.h.author > 0)
 	print(paste("reading input from '", input.filename, "' and parsing out into individual entries", sep=""))
 	h <- openxlsx::read.xlsx(input.filename)
 	if (remove.duplicates) {
@@ -102,18 +111,18 @@ parse_raw_data <- function(input.filename,
 	print("    on combined data")
 	all.query <- all.merged.withblanks
 	all.query[neither.match] <- as.vector(result.df$original.string, mode = "character")[neither.match]
-	result.df <- book.parsing::run.multistep.clustering(result.df, all.query, "combined", 5)
+	result.df <- book.parsing::run.multistep.clustering(result.df, all.query, "combined", cutree.h.combined)
 	## run multi-step clustering and labeling on just the titles, and the unmatched patterns
 	print("    on titles only")
 	title.query <- result.df$predicted.title
 	title.query[neither.match] <- as.vector(result.df$original.string, mode = "character")[neither.match]
-	result.df <- book.parsing::run.multistep.clustering(result.df, title.query, "title", 3)
+	result.df <- book.parsing::run.multistep.clustering(result.df, title.query, "title", cutree.h.title)
 	## run multi-step clustering and labeling on just the authors, without the unmatched patterns
 	print("    on authors only")
 	result.df.nomatch <- result.df[neither.match,]
 	result.df.withmatch <- result.df[!neither.match,]
 	author.query <- result.df.withmatch$predicted.author
-	result.df.withmatch <- book.parsing::run.multistep.clustering(result.df.withmatch, author.query, "author", 3)
+	result.df.withmatch <- book.parsing::run.multistep.clustering(result.df.withmatch, author.query, "author", cutree.h.author)
 	result.df.nomatch$author.search.input <- NA
 	result.df.nomatch$author.consensus.label <- NA
 	result.df <- rbind(result.df.withmatch, result.df.nomatch)

--- a/R/parse_raw_data.R
+++ b/R/parse_raw_data.R
@@ -13,6 +13,9 @@
 #' @param known.matches character string, a file of curated {Entry -> {Title, Author}} pairs, or NA
 #' @param remove.duplicates logical, whether to remove rows in input data that are absolutely identical (will report on this if so)
 #' @param disable.nlp.correction logical, whether to just report the data as detected from input, without applying NLP corrections
+#' @param cutree.h.combined numeric, `cutree` h parameter for hierarchical cluster calling for combined title/author queries
+#' @param cutree.h.title numeric, `cutree` h parameter for hierarchical cluster calling for titles only
+#' @param cutree.h.author numeric, `cutree` h parameter for hierarchical cluster calling for authors only
 #' @export
 parse_raw_data <- function(input.filename,
 						   output.prefix,

--- a/README.md
+++ b/README.md
@@ -17,17 +17,79 @@ This repo is a formatted R library and can be installed with devtools::install_g
 
 ## Usage
 
-TBD
+First, load the relevant libary:
+
+`require(book.parsing)`
+
+The most basic usage is as follows:
+
+`book.parsing::parse_raw_data("input.xlsx", "output_step1")
+
+After the above step, please manually inspect the output `output_step1.tsv`
+for any incorrect assignments or needed adjustments. All changes should be made to
+the `final.title` and `final.author` columns. Any entries in the `final.title`
+or `final.author` columns can be left as `NA`; such rows will be excluded
+by `book.parsing::process.output`. When that is complete, use the following
+command to postprocess and summarize the edited output file:
+
+`book.parsing::process.output("output_step1.tsv", "output_step2", TRUE)`
+
+The results will be stored in `output_step2.final-results.tsv`.
 
 ## Input Formats
 
-TBD
+### First round: `book.parsing::parse_raw_data`
+
+For minimal usage, assume the user has a file `input.xlsx` structured as follows:
+a first column that is ignored; then sets of three columns each of the header format
+`Category name without dashes - Nomination #`. For rows, the header row is followed
+by arbitrarily many rows with either valid entries or empty cells.
+
+### Second round: `book.parsing::process.output`
+
+This should generally be an output file from the above execution of `book.parsing::parse_raw_data`.
+It is expected that there will need to be some user intervention to approach 100% accuracy; those
+changes should be made to the `final.title` and `final.author` columns. `NA` entries in those
+columns are treated as missing data and ignored.
 
 ## Output Formats
 
-TBD
+### First round: `book.parsing::parse_raw_data`
+
+The function `book.parsing::parse_raw_data` aggregates entries across categories
+and reports them, along with their intermediate NLP results and final classification,
+in a tabular format. That output format contains the following columns:
+
+ - `raw.string`: the original entry encountered in the input file
+ - `original.string`: the original entry, with any provided `preprocessing.overrides` replacements applied
+ - `category`: which category the entry was initially found in
+ - `submitter.comments`: in a few instances, freetext entry contained parenthetical additions, which are stored here, or `NA`
+ - `predicted.title`: following expected `TITLE by AUTHOR` or `TITLE - AUTHOR` or `TITLE/AUTHOR` format: the predicted title
+ - `predicted.author`: following expected `TITLE by AUTHOR` or `TITLE - AUTHOR` or `TITLE/AUTHOR` format: the predicted author
+ - `combined.search.input`: the exact query used in combined Title/Author clustering; this is a mildly manipulated version of the original input
+ - `combined.consensus.label`: the result of combined Title/Author clustering
+ - `title.search.input`: the exact query used in Title clustering; when `predicted.title` is `NA`, this is the original query
+ - `title.consensus.label`: the result of the Title clustering
+ - `author.search.input`: the exact query used in Author clustering; this is just the predicted author, though clustering is run with `NA` entries removed
+ - `author.consensus.label`: the result of the Author clustering
+ - `final.title`: the final predicted title label for this entry, after NLP, standardized formatting, and `postprocessing.overrides` applied; or `NA`
+ - `final.author`: the final predicted author label for this entry, after NLP, standardized formatting, and `postprocessing.overrides` applied; or `NA`
+ - `final.message`: a `Success` or `Fail` message with some description of the result status; can be used to assess where the program is confident, or possibly needs improvement
+
+### Second round: `book.parsing::process.output
+
+The function `book.parsing::process.output` aggregates harmonized data within categories
+and reports them, such that the results within categories can be used for downstream purposes.
+The tabular reporting format contains the following columns:
+ - `Category`: the submission category in which the entry was found
+ - `Vote`: the harmonized vote corresponding to the original free text entry or entries
+ - `Title`: the Title component of the Vote; useful for sorting
+ - `Author`: the Author component of the Vote; useful for sorting
+ - `Count`: the number of times this Vote was encountered in this particular Category
 
 ## Version History
+
+13 December 2020: v1.0.1, with improved userspace parameters in `parse_raw_data`, and a much-improved README.
 
 12 December 2020: v1.0.0 release, with compatibility to training dataset.
 

--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ TBD
 
 ## Version History
 
+12 December 2020: v1.0.0 release, with compatibility to training dataset.
+
 12 December 2020: initial commit with minimal working solution.

--- a/man/parse_raw_data.Rd
+++ b/man/parse_raw_data.Rd
@@ -31,6 +31,12 @@ parse_raw_data(
 \item{remove.duplicates}{logical, whether to remove rows in input data that are absolutely identical (will report on this if so)}
 
 \item{disable.nlp.correction}{logical, whether to just report the data as detected from input, without applying NLP corrections}
+
+\item{cutree.h.combined}{numeric, \code{cutree} h parameter for hierarchical cluster calling for combined title/author queries}
+
+\item{cutree.h.title}{numeric, \code{cutree} h parameter for hierarchical cluster calling for titles only}
+
+\item{cutree.h.author}{numeric, \code{cutree} h parameter for hierarchical cluster calling for authors only}
 }
 \description{
 This function loads an Excel spreadsheet containing formatted output

--- a/man/parse_raw_data.Rd
+++ b/man/parse_raw_data.Rd
@@ -11,7 +11,10 @@ parse_raw_data(
   postprocessing.overrides = NA,
   known.matches = NA,
   remove.duplicates = TRUE,
-  disable.nlp.correction = FALSE
+  disable.nlp.correction = FALSE,
+  cutree.h.combined = 5,
+  cutree.h.title = 3,
+  cutree.h.author = 3
 )
 }
 \arguments{


### PR DESCRIPTION
Top-level calls to `book.parsing::parse_raw_data` can now set `cutree` `h` parameter, separately for the combined (Title + Author), title only, and author only clusterings. And the README actually says what the code does and how to use it, for the most part. Not sure whether this will replace the vignette ultimately, but at least if I forget about this project completely in 12 hours, I'll still be able to read the README a year from now.

re #4 #13
